### PR TITLE
Hotfix: Use ubuntu:bionic as base image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:bionic 
 RUN apt-get update && apt-get install -y apache2 && apt-get -y clean
 ADD frontend.tar.gz /var/www/html/
 ADD mod_status /tmp/


### PR DESCRIPTION
Travar a versão da imagem base do container no Ubuntu Bionic.